### PR TITLE
正确处理数据库连接的异常

### DIFF
--- a/src/main/java/com/github/hcsp/exception/DatabaseReader.java
+++ b/src/main/java/com/github/hcsp/exception/DatabaseReader.java
@@ -5,25 +5,42 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 
 public class DatabaseReader {
     public static void main(String[] args) {
         File projectDir = new File(System.getProperty("basedir", System.getProperty("user.dir")));
         String jdbcUrl = "jdbc:h2:file:" + new File(projectDir, "test").getAbsolutePath();
         System.out.println(jdbcUrl);
-
-        Connection connection = DriverManager.getConnection(jdbcUrl, "sa", "");
-        PreparedStatement statement =
-                connection.prepareStatement("select * from PULL_REQUESTS where number > ?");
-        statement.setInt(1, 0);
-        ResultSet resultSet = statement.executeQuery();
-        while (resultSet.next()) {
-            System.out.println(
-                    resultSet.getInt(1)
-                            + " "
-                            + resultSet.getString(2)
-                            + " "
-                            + resultSet.getString(2));
+        Connection connection = null;
+        PreparedStatement statement = null;
+        try {
+            connection = DriverManager.getConnection(jdbcUrl, "sa", "");
+            statement =
+                    connection.prepareStatement("select * from PULL_REQUESTS where number > ?");
+            statement.setInt(1, 0);
+            ResultSet resultSet = statement.executeQuery();
+            while (resultSet.next()) {
+                System.out.println(
+                        resultSet.getInt(1)
+                                + " "
+                                + resultSet.getString(2)
+                                + " "
+                                + resultSet.getString(2));
+            }
+        } catch (SQLException se) {
+            se.printStackTrace();
+        } finally {
+            try {
+                if (connection != null) {
+                    connection.close();
+                }
+                if (statement !=null) {
+                    statement.close();
+                }
+            } catch (SQLException se2) {
+                se2.printStackTrace();
+            }
         }
     }
 }


### PR DESCRIPTION
#### 测试发现缺少 java.sql.SQLException;这个异常包，添加后把connect 和PreparedStatement statement关闭。
##### 其实这道题都是跟着网上一些教程完成，大多数解释都是为了避免连接池被占满还有内存不足的问题，但是还不是十分理解。

###### 还有一个是在IDE里面打开Java的文件十分不方便，很难进行文档的阅读，编写的时候也不方便，怎么能够解决这样子的问题？